### PR TITLE
Add support for multiple exams at the same time

### DIFF
--- a/client/ui.ts
+++ b/client/ui.ts
@@ -49,7 +49,7 @@ export class UI {
 		else {
 			// No active session found, show login form or exam mode form
 			this._loginScreen = new LoginScreenUI(auth);
-			this._examModeScreen = new ExamModeUI(auth, this._loginScreen, null);
+			this._examModeScreen = new ExamModeUI(auth, this._loginScreen);
 
 			// Subscribe to data change events, so that we can show the exam mode screen when an exam is started
 			data.addDataChangeListener((data: DataJson | undefined) => {
@@ -120,7 +120,7 @@ export class UI {
 		}
 
 		const examsForHost: ExamForHost[] = window.data.dataJson.exams_for_host;
-		const ongoingExam = examsForHost.find((exam) => {
+		const ongoingExams = examsForHost.filter((exam) => {
 			const now = new Date();
 			const beginAt = new Date(exam.begin_at);
 			const beginExamModeAt = new Date(beginAt.getTime() - UI.SHOW_EXAM_MODE_MINUTES_BEFORE_BEGIN * 60 * 1000);
@@ -128,19 +128,20 @@ export class UI {
 			return now >= beginExamModeAt && now < endAt;
 		});
 
-		const examModeExam = this._examModeScreen?.exam;
-		if (ongoingExam !== undefined) {
-			if (examModeExam === null || examModeExam?.id !== ongoingExam.id) { // Only set exam mode again if the exam has changed or was not set before
+		const examModeIds = this._examModeScreen?.examIds;
+		if (ongoingExams.length > 0) {
+			// Only set exam mode if the exam that is starting soon is not already in the list of exam ids displayed in exam mode
+			if (!this._examModeScreen?.examMode || !ongoingExams.some((exam) => examModeIds?.includes(exam.id))) {
 				console.log("Activating exam mode login UI");
-				this._examModeScreen?.setExam(ongoingExam);
+				this._examModeScreen?.enableExamMode(ongoingExams);
 				// Exam mode screen is shown automatically by the function above
 			}
 			return true;
 		}
 		else {
-			if (examModeExam !== null) { // Only unset exam mode if it was set before
+			if (this._examModeScreen?.examMode) { // Only unset exam mode if it was set before
 				console.log('Deactivating exam mode login UI');
-				this._examModeScreen?.setExam(null);
+				this._examModeScreen?.disableExamMode();
 				// Login screen is shown automatically by the function above
 			}
 			return false;

--- a/client/ui.ts
+++ b/client/ui.ts
@@ -119,6 +119,7 @@ export class UI {
 			return false;
 		}
 
+		// Get exams that are starting soon
 		const examsForHost: ExamForHost[] = window.data.dataJson.exams_for_host;
 		const ongoingExams = examsForHost.filter((exam) => {
 			const now = new Date();
@@ -128,10 +129,9 @@ export class UI {
 			return now >= beginExamModeAt && now < endAt;
 		});
 
-		const examModeIds = this._examModeScreen?.examIds;
 		if (ongoingExams.length > 0) {
 			// Only set exam mode if the exam that is starting soon is not already in the list of exam ids displayed in exam mode
-			if (!this._examModeScreen?.examMode || !ongoingExams.some((exam) => examModeIds?.includes(exam.id))) {
+			if (!this._examModeScreen?.examMode || !ongoingExams.some((exam) => this._examModeScreen?.examIds.includes(exam.id))) {
 				console.log("Activating exam mode login UI");
 				this._examModeScreen?.enableExamMode(ongoingExams);
 				// Exam mode screen is shown automatically by the function above

--- a/client/uis/screens/examscreen.ts
+++ b/client/uis/screens/examscreen.ts
@@ -8,7 +8,8 @@ export class ExamModeUI extends UIScreen {
 	public static readonly EXAM_PASSWORD: string = 'exam';
 
 	public readonly _form: UIExamModeElements;
-	private _exam: ExamForHost | null = null;
+	private _examMode: boolean = false;
+	private _examIds: number[] = [];
 	private _loginScreen: LoginScreenUI;
 	protected _events: AuthenticatorEvents = {
 		authenticationStart: () => {
@@ -30,7 +31,7 @@ export class ExamModeUI extends UIScreen {
 		},
 	};
 
-	public constructor(auth: Authenticator, loginUI: LoginScreenUI, exam: ExamForHost | null = null) {
+	public constructor(auth: Authenticator, loginUI: LoginScreenUI) {
 		super(auth);
 
 		// Keep a reference to the login screen so that we can show it when the exam is over
@@ -45,35 +46,37 @@ export class ExamModeUI extends UIScreen {
 		} as UIExamModeElements;
 
 		this._initForm();
-
-		if (exam !== null) {
-			this.setExam(exam);
-		}
 	}
 
 	/**
 	 * Set the exam to display on the exam mode screen.
 	 * If no exam is given, the exam mode screen will be hidden and the login screen will be shown instead.
-	 * @returns true if the exam mode screen should be shown, false if the login screen is shown instead
 	 */
-	public setExam(exam: ExamForHost | null): boolean {
-		this._exam = exam;
-		this._populateData();
-
-		if (this._exam === null) {
-			this.hideForm();
-			this._loginScreen.showForm();
-			return false;
-		}
-		else {
-			this._loginScreen.hideForm();
-			this.showForm();
-			return true;
-		}
+	public enableExamMode(exams: ExamForHost[]): void {
+		this._examMode = true;
+		this._examIds = exams.map((exam) => exam.id);
+		this._populateData(exams);
+		this._loginScreen.hideForm();
+		this.showForm();
 	}
 
-	public get exam(): ExamForHost | null {
-		return this._exam;
+	/**
+	 * Disable exam mode and show the default login screen instead.
+	 */
+	public disableExamMode(): void {
+		this._examMode = false;
+		this._examIds = [];
+		this._populateData([]);
+		this.hideForm();
+		this._loginScreen.showForm();
+	}
+
+	public get examMode(): boolean {
+		return this._examMode;
+	}
+
+	public get examIds(): number[] {
+		return this._examIds;
 	}
 
 	protected _initForm(): void {
@@ -82,40 +85,52 @@ export class ExamModeUI extends UIScreen {
 		// This event gets called when the user clicks the unlock button or submits the lock screen form in any other way
 		form.examStartButton.addEventListener('click', (event: Event) => {
 			event.preventDefault();
-			if (this._exam !== null) {
-				// Always log in with the username and password given by the back-end server.
-				// If no username and password are given, use the default username and password.
+			if (this._examMode) {
 				this._auth.login(ExamModeUI.EXAM_USERNAME, ExamModeUI.EXAM_PASSWORD);
-			}
-			else {
-				console.error('Exam is null');
-				window.ui.setDebugInfo('Exam is null');
 			}
 		});
 	}
 
-	private _populateData(): void {
+	private _populateData(examsToPopulate: ExamForHost[]): void {
 		const form = this._form as UIExamModeElements;
 
-		if (this._exam === null) {
+		if (examsToPopulate.length === 0) {
 			// Unset text that states which exams can be started today
 			form.examProjectsText.innerText = '';
 		}
 		else {
-			// Populate text that states which exams can be started today
-			const exam = window.data.dataJson?.exams.find((exam) => exam.id === this._exam?.id);
-			if (exam === undefined) {
-				console.error('Exam not found in data.json');
-				window.ui.setDebugInfo('Exam not found in data.json');
+			// Find all exams in the data.json file that match the ids in the exams variable
+			const exams = window.data.dataJson?.exams.filter((exam) => examsToPopulate.some((examToPopulate) => exam.id === examToPopulate.id));
+
+			if (exams === undefined) {
+				console.error('Failed to find exams in data.json');
+				window.ui.setDebugInfo('Failed to find exams in data.json');
 				return;
 			}
-			const projectsText = exam.projects.map((project) => project.name).join(', ');
-			form.examProjectsText.innerText = projectsText;
 
-			const examStart = new Date(this._exam.begin_at);
-			const examEnd = new Date(this._exam.end_at);
-			form.examStartText.innerText = examStart.toLocaleTimeString("en-NL", { hour: '2-digit', minute: '2-digit' });
-			form.examEndText.innerText = examEnd.toLocaleTimeString("en-NL", { hour: '2-digit', minute: '2-digit' });
+			// Find the earliest start time for an exam that should be displayed right now
+			const earliestExam = exams.reduce((earliest, exam) => {
+				const beginAt = new Date(exam.begin_at);
+				if (earliest === null || beginAt < earliest) {
+					return beginAt;
+				}
+				return earliest;
+			}, new Date(exams[0].begin_at));
+
+			// Find the latest end time for an exam that should be displayed right now
+			const latestExam = exams.reduce((latest, exam) => {
+				const endAt = new Date(exam.end_at);
+				if (latest === null || endAt > latest) {
+					return endAt;
+				}
+				return latest;
+			}, new Date(exams[0].end_at));
+
+			// Combine all possible projects for exams that can be started right now
+			const projectsText = exams.flatMap((exam) => exam.projects.map((project) => project.name)).join(', ');
+			form.examProjectsText.innerText = projectsText;
+			form.examStartText.innerText = earliestExam.toLocaleTimeString("en-NL", { hour: '2-digit', minute: '2-digit' });
+			form.examEndText.innerText = latestExam.toLocaleTimeString("en-NL", { hour: '2-digit', minute: '2-digit' });
 		}
 	}
 

--- a/client/uis/screens/examscreen.ts
+++ b/client/uis/screens/examscreen.ts
@@ -49,10 +49,13 @@ export class ExamModeUI extends UIScreen {
 	}
 
 	/**
-	 * Set the exam to display on the exam mode screen.
-	 * If no exam is given, the exam mode screen will be hidden and the login screen will be shown instead.
+	 * Enable exam mode for a list of exams currently ongoing (usually just 1).
+	 * If the array of exams is empty, nothing will happen.
 	 */
 	public enableExamMode(exams: ExamForHost[]): void {
+		if (exams.length === 0) {
+			return;
+		}
 		this._examMode = true;
 		this._examIds = exams.map((exam) => exam.id);
 		this._populateData(exams);
@@ -71,10 +74,16 @@ export class ExamModeUI extends UIScreen {
 		this._loginScreen.showForm();
 	}
 
+	/**
+	 * Get whether the exam mode screen is currently displayed.
+	 */
 	public get examMode(): boolean {
 		return this._examMode;
 	}
 
+	/**
+	 * Get the ids of the exams that are currently displayed on the exam mode screen.
+	 */
 	public get examIds(): number[] {
 		return this._examIds;
 	}
@@ -97,6 +106,8 @@ export class ExamModeUI extends UIScreen {
 		if (examsToPopulate.length === 0) {
 			// Unset text that states which exams can be started today
 			form.examProjectsText.innerText = '';
+			form.examStartText.innerText = 'unknown';
+			form.examEndText.innerText = 'unknown';
 		}
 		else {
 			// Find all exams in the data.json file that match the ids in the exams variable
@@ -128,6 +139,8 @@ export class ExamModeUI extends UIScreen {
 
 			// Combine all possible projects for exams that can be started right now
 			const projectsText = exams.flatMap((exam) => exam.projects.map((project) => project.name)).join(', ');
+
+			// Display the projects and the time range in which the exams can be started
 			form.examProjectsText.innerText = projectsText;
 			form.examStartText.innerText = earliestExam.toLocaleTimeString("en-NL", { hour: '2-digit', minute: '2-digit' });
 			form.examEndText.innerText = latestExam.toLocaleTimeString("en-NL", { hour: '2-digit', minute: '2-digit' });


### PR DESCRIPTION
Before, only one exam was displayed (the first one fetched from the Intra API). Now, exams are combined and all projects possible are displayed.

This is useful if you run both a piscine exam and a common core exam at the same time using two exams instead of one.