### PR TITLE
Idle logout rework

### DIFF
--- a/client/uis/screens/lockscreen.ts
+++ b/client/uis/screens/lockscreen.ts
@@ -3,7 +3,7 @@ import { LightDMUser, ThemeUtils } from "nody-greeter-types";
 import { UIScreen, UILockScreenElements } from "../screen";
 import { UI } from "../../ui";
 
-const PATH_LOCK_TIMESTAMP_PREFIX = '/tmp//tmp/codam_web_greeter_lock_timestamp';
+const PATH_LOCK_TIMESTAMP_PREFIX = '/tmp/codam_web_greeter_lock_timestamp';
 
 export class LockScreenUI extends UIScreen {
 	public readonly _form: UILockScreenElements;
@@ -48,9 +48,7 @@ export class LockScreenUI extends UIScreen {
 
 		// Check when the screen was locked every minute (delete the lock_timestamp file in /tmp to prevent the automated logout)
 		setInterval(this._getAndSetLockedTimestamp.bind(this), 60000);
-
-		// Also check in 10 seconds (give the greeter-setup script time to finish)
-		setTimeout(this._getAndSetLockedTimestamp.bind(this), 10000);
+		this._getAndSetLockedTimestamp();
 	}
 
 	protected _initForm(): void {

--- a/systemd/system/codam-web-greeter-idler.sh
+++ b/systemd/system/codam-web-greeter-idler.sh
@@ -40,6 +40,6 @@ while IFS= read -r line; do
 		/usr/bin/echo "Session for user $USERNAME has been idle for over 42 minutes (idletime $IDLE_TIME ms, time_since_lock $TIME_SINCE_LOCK ms), forcing logout now by restarting lightdm"
 		/usr/bin/systemctl restart lightdm
 	else
-		/usr/bin/echo "Session for $USERNAME has been idle for $((IDLE_TIME / 1000)) seconds"
+		/usr/bin/echo "Session for $USERNAME has been idle for $((IDLE_TIME / 1000)) seconds, screen locked for $((TIME_SINCE_LOCK / 1000)) seconds"
 	fi
 done <<< "$WHO_OUTPUT"

--- a/systemd/system/codam-web-greeter-idler.sh
+++ b/systemd/system/codam-web-greeter-idler.sh
@@ -17,11 +17,27 @@ while IFS= read -r line; do
 	if ! [[ "$DISPLAY" =~ ^: ]]; then
 		continue
 	fi
+
 	# Get idle time from X-session using sudo
+	# This time is used to determine if the session has been idle for too long (possibly without locking the screen)
 	IDLE_TIME=$(/usr/bin/sudo -u "$USERNAME" DISPLAY="$DISPLAY" /usr/bin/xprintidle)
-	# Check if session has been idle for over 42 minutes
-	if [ "$IDLE_TIME" -gt 2520000 ]; then
-		/usr/bin/echo "Session for user $USERNAME has been idle for over 42 minutes (idletime $IDLE_TIME ms), forcing logout now by restarting lightdm"
+
+	# Check if lock_timestamp file exists, and if so read the locked_at_timestamp
+	# This time is used to determine if the screen lock has been active for too long
+	# Sometimes xprintidle doesn't work properly when the screen is locked due to programs running in the user session in the background
+	TIME_SINCE_LOCK=$((0)) # Placeholder
+	if [ -f "/tmp/codam_web_greeter_lock_timestamp_$USERNAME" ]; then
+		# Get the locked_at_timestamp from the file
+		LOCKED_AT_TIMESTAMP=$(/usr/bin/awk '{print $1}' "/tmp/codam_web_greeter_lock_timestamp_$USERNAME")
+		# Calculate the time since the session was locked
+		TIME_SINCE_LOCK=$((($(date +%s) - LOCKED_AT_TIMESTAMP) * 1000))
+	fi
+
+	# Check if session has been idle for long enough
+	MAX_IDLE_TIME_MINUTES=$((42))
+	MAX_IDLE_TIME=$((MAX_IDLE_TIME_MINUTES * 60 * 1000))
+	if [ "$IDLE_TIME" -gt "$MAX_IDLE_TIME" ] || [ "$TIME_SINCE_LOCK" -gt "$MAX_IDLE_TIME" ]; then
+		/usr/bin/echo "Session for user $USERNAME has been idle for over 42 minutes (idletime $IDLE_TIME ms, time_since_lock $TIME_SINCE_LOCK ms), forcing logout now by restarting lightdm"
 		/usr/bin/systemctl restart lightdm
 	else
 		/usr/bin/echo "Session for $USERNAME has been idle for $((IDLE_TIME / 1000)) seconds"


### PR DESCRIPTION
Rework of the idling system. Instead of assuming the screen was locked right as the greeter was started and using `xprintidle` to get idletime, get the screen lock time from a file in `/tmp`. This file is created by the greeter-setup lightdm hook if running the latest version of [ansible-codam-web-greeter](https://github.com/codam-coding-college/ansible-codam-web-greeter). Tested in 42 Bangkok.