### PR TITLE
Add backlight control

### DIFF
--- a/client/main.ts
+++ b/client/main.ts
@@ -10,6 +10,7 @@ declare global {
 		auth: Authenticator;
 		ui: UI;
 		idler: Idler;
+		debugKeys: boolean;
 
 		sleep(ms: number): Promise<void>;
 		restartComputer(): boolean;
@@ -68,6 +69,7 @@ async function initGreeter(): Promise<void> {
 	window.auth = new Authenticator();
 	window.ui = new UI(window.data, window.auth);
 	window.idler = new Idler(window.ui.isLockScreen);
+	window.debugKeys = false;
 
 	// Add reboot keybind to reboot on ctrl+alt+del
 	// only when the lock screen is not shown
@@ -82,6 +84,10 @@ async function initGreeter(): Promise<void> {
 					window.ui.setDebugInfo('Exam mode override enabled');
 					window.ui.overrideExamMode();
 					break;
+				case 'KeyD': // Ctrl + Alt + D = debug keys: show pressed key in debug info
+					window.debugKeys = true;
+					window.ui.setDebugInfo('Debug keys enabled');
+					break;
 			}
 		}
 		else { // Regular keybinds
@@ -93,6 +99,9 @@ async function initGreeter(): Promise<void> {
 					window.brightness.increase();
 					break;
 			}
+		}
+		if (window.debugKeys) {
+			window.ui.setDebugInfo(`Key pressed: ${e.code} (${e.key})${e.ctrlKey ? ' + Ctrl' : ''}${e.altKey ? ' + Alt' : ''}${e.shiftKey ? ' + Shift' : ''}${e.metaKey ? ' + Meta' : ''}`);
 		}
 	});
 }

--- a/client/main.ts
+++ b/client/main.ts
@@ -75,28 +75,30 @@ async function initGreeter(): Promise<void> {
 	// only when the lock screen is not shown
 	document.addEventListener('keydown', (e) => {
 		if (e.ctrlKey && e.altKey) { // Special keybinds
-			switch (e.code) {
+			switch (e.key) {
 				case 'Delete': // Ctrl + Alt + Delete = reboot computer
 					window.ui.setDebugInfo('Reboot requested through LightDM');
 					window.restartComputer();
 					break;
-				case 'KeyE': // Ctrl + Alt + E = override exam mode
+				case 'e': // Ctrl + Alt + E = override exam mode
 					window.ui.setDebugInfo('Exam mode override enabled');
 					window.ui.overrideExamMode();
 					break;
-				case 'KeyD': // Ctrl + Alt + D = debug keys: show pressed key in debug info
+				case 'd': // Ctrl + Alt + D = debug keys: show pressed key in debug info
 					window.debugKeys = true;
 					window.ui.setDebugInfo('Debug keys enabled');
 					break;
 			}
 		}
 		else { // Regular keybinds
-			switch (e.code) {
-				case 'F1': // F1 = Decrease brightness
+			switch (e.key) {
+				case 'BrightnessDown': // Brightness down key
+				case 'F1': // F1 = Decrease brightness (F1 and F14 are often the same key)
 				case 'F14': // F14 = Decrease brightness (on some keyboards, e.g. Cherry)
 					window.brightness.decrease();
 					break;
-				case 'F2': // F2 = Increase brightness
+				case 'BrightnessUp': // Brightness up key
+				case 'F2': // F2 = Increase brightness (F2 and F15 are often the same key)
 				case 'F15': // F15 = Increase brightness (on some keyboards, e.g. Cherry)
 					window.brightness.increase();
 					break;

--- a/client/main.ts
+++ b/client/main.ts
@@ -74,6 +74,9 @@ async function initGreeter(): Promise<void> {
 	// Add reboot keybind to reboot on ctrl+alt+del
 	// only when the lock screen is not shown
 	document.addEventListener('keydown', (e) => {
+		if (window.debugKeys) {
+			window.ui.setDebugInfo(`Key pressed: ${e.code} (${e.key})${e.ctrlKey ? ' + Ctrl' : ''}${e.altKey ? ' + Alt' : ''}${e.shiftKey ? ' + Shift' : ''}${e.metaKey ? ' + Meta' : ''}`);
+		}
 		if (e.ctrlKey && e.altKey) { // Special keybinds
 			switch (e.key) {
 				case 'Delete': // Ctrl + Alt + Delete = reboot computer
@@ -85,9 +88,9 @@ async function initGreeter(): Promise<void> {
 					window.ui.overrideExamMode();
 					break;
 				case 'd': // Ctrl + Alt + D = debug keys: show pressed key in debug info
-					window.debugKeys = true;
-					window.ui.setDebugInfo('Debug keys enabled');
-					break;
+					window.debugKeys = (window.debugKeys) ? false : true;
+					window.ui.setDebugInfo(`Debug keys: ${(window.debugKeys ? 'enabled' : 'disabled')}`);
+					return;
 			}
 		}
 		else { // Regular keybinds
@@ -103,9 +106,6 @@ async function initGreeter(): Promise<void> {
 					window.brightness.increase();
 					break;
 			}
-		}
-		if (window.debugKeys) {
-			window.ui.setDebugInfo(`Key pressed: ${e.code} (${e.key})${e.ctrlKey ? ' + Ctrl' : ''}${e.altKey ? ' + Alt' : ''}${e.shiftKey ? ' + Shift' : ''}${e.metaKey ? ' + Meta' : ''}`);
 		}
 	});
 }

--- a/client/main.ts
+++ b/client/main.ts
@@ -93,9 +93,11 @@ async function initGreeter(): Promise<void> {
 		else { // Regular keybinds
 			switch (e.code) {
 				case 'F1': // F1 = Decrease brightness
+				case 'F14': // F14 = Decrease brightness (on some keyboards, e.g. Cherry)
 					window.brightness.decrease();
 					break;
 				case 'F2': // F2 = Increase brightness
+				case 'F15': // F15 = Increase brightness (on some keyboards, e.g. Cherry)
 					window.brightness.increase();
 					break;
 			}


### PR DESCRIPTION
This PR adds backlight control to the codam-web-greeter using the <kbd>F1</kbd> and <kbd>F2</kbd> keys (alternatively, the <kbd>F14</kbd> and <kbd>F15</kbd> keys).

It requires changes to the web-greeter config on the host and access to the xbacklight command utility, preferrably installed through [acpilight](https://gitlab.com/wavexx/acpilight). An upcoming release of [ansible-codam-web-greeter](https://github.com/codam-coding-college/ansible-codam-web-greeter) will make these changes.

In addition to the feature mentioned above, this PR also adds a way to debug `keydown` event keycodes by using the <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>D</kbd> key combination. Pressed keys will then be printed in the debug info on the bottom right of the greeter.